### PR TITLE
[CMake] Revert changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(Sofa.Component.Topology REQUIRED) # Needed to use SofaCore, SofaHel
 find_package(Sofa.Component.StateContainer REQUIRED) # Needed to use SofaCore, SofaHelper and SofaDefaultType
 find_package(Threads REQUIRED)
 
-find_package(OpenIGTLink REQUIRED) # Needed to use SofaCore, SofaHelper and SofaDefaultType
+find_package(OpenIGTLink QUIET) # Needed to use SofaCore, SofaHelper and SofaDefaultType
 if(NOT OpenIGTLink_FOUND )
         message("SofaIGTLink: DEPENDENCY OpenIGTLink NOT FOUND, fetching OpenIGTLink...")
         include(FetchContent)


### PR DESCRIPTION
The package is required but finding it there is not mandatory, because if not found it will be fetched. 
@RafaelPalomar why did you need to put it as required ? I am sorry to come back on this, I merged your PR a bit too late in the evening, I should have been more careful... 